### PR TITLE
Corrected Issue of missing math libraries: mpc, mpfr, gmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ pip install -r requirements.txt
 python setup.py install
 ```
 
+### For anaconda users:
+
+```
+bash install_for_anaconda_users.sh
+```
+
 ## literature
 
 As both Homomorphic Encryption and Deep Learning are still somewhat sparsely known, below is a curated list of relevant reading materials to bring you up to speed with the major concepts and themes of these exciting fields.

--- a/install_for_anaconda_users.sh
+++ b/install_for_anaconda_users.sh
@@ -1,0 +1,8 @@
+conda create -n openmined python=3.4
+source activate openmined
+conda install -c anaconda mpc
+conda install -c anaconda gmp
+conda install -c anaconda mpfr
+conda install gmpy2 --channel conda-forge
+pip install -r requirements.txt
+python setup.py install


### PR DESCRIPTION
All of them are required for installation of gmpy2
** This fix is for anaconda users**