### PR TITLE
Add jupyter to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyRserve
 numpy
 phe
 line_profiler
+jupyter


### PR DESCRIPTION
So that we can run `jupyter notebook` in the `notebooks` directory.