### PR TITLE
:construction_worker: build: create binary `syft_cmd` during install

### DIFF
--- a/bin/syft_cmd
+++ b/bin/syft_cmd
@@ -1,3 +1,4 @@
+#!python
 import syft
 import pickle
 import sys

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(
     classifiers=[
         "Development Status :: 1 - Alpha",
     ],
+    scripts=['bin/syft_cmd'],
     install_requires=requirements,
 )


### PR DESCRIPTION
Should allow us to just install the git repository and have the command available.