### PR TITLE
:ant: fix: no command shows help

### DIFF
--- a/bin/syft_cmd
+++ b/bin/syft_cmd
@@ -20,7 +20,7 @@ with indent(4, quote='>>>'):
     # puts(colored.red('NOT Files detected: ') + str(args.not_files))
     # puts(colored.red('Grouped Arguments: ') + str(dict(args.grouped)))
 
-    command = str(args.all[0])
+    command = str(args.all[0] if len(args.all) else '')
     puts(colored.blue('Command: ') + command)
 
     if(command == 'create_model'):


### PR DESCRIPTION
Another minor fix. Just calling `syft` resulted in an error because `args.all` didn't have any elements to index