### PR TITLE
fix install.sh script

### DIFF
--- a/syftbox/server/templates/install.sh
+++ b/syftbox/server/templates/install.sh
@@ -197,11 +197,7 @@ do_install() {
     install_syftbox
 
     success "Installation completed!"
-    if [ $RUN_CLIENT -eq 1 ]; then
-        exec ~/.local/bin/syftbox client < /dev/tty
-    else
-        post_install
-    fi
+    post_install
 }
 
 do_install "$@" || exit 1


### PR DESCRIPTION
Test:
Run a python server to return the install script:
```bash
cd syftbox/server/templates
python3 -m http.server 8000
```
Then in another terminal, run 
```bash
curl -LsSf http://localhost:8000/install.sh | sh -s -- run
```