### PR TITLE
update logs

### DIFF
--- a/syftbox/client/plugins/sync.py
+++ b/syftbox/client/plugins/sync.py
@@ -355,8 +355,9 @@ def get_remote_state(client_config: ClientConfig, sub_path: str):
         try:
             state_response = response.json()
         except Exception as e:
-            print("/dir_state response Not JSON:", response.text)
-            raise e
+            logger.error(f"""Failed to call /dir_state for {sub_path} response Not JSON: {response.text}. \
+This may be related to broken (empty!) syftperm files""")
+            return None
 
         if response.status_code == 200:
             if isinstance(state_response, dict) and "dir_state" in state_response:
@@ -577,7 +578,7 @@ def sync_down(client_config) -> int:
 
         remote_dir_state = get_remote_state(client_config, datasite)
         if not remote_dir_state:
-            # logger.info(f"No remote state for dir: {datasite}")
+            logger.info(f"Could not find remote state for {datasite}, skipping syncing down")
             continue
 
         pre_filter_changes = diff_dirstate(new_dir_state, remote_dir_state)


### PR DESCRIPTION
Instead of

```
2024-10-17 13:26:58.865 | ERROR    | plugins.sync:get_remote_state:378 - Failed to call /dir_state on the server
2024-10-17 13:26:58.865 | ERROR    | plugins.sync:get_remote_state:379 - Expecting value: line 1 column 1 (char 0)
Traceback (most recent call last):

  File "/Users/koen/miniconda3/envs/syftbox/lib/python3.12/threading.py", line 1032, in _bootstrap
    self._bootstrap_inner()
    │    └ <function Thread._bootstrap_inner at 0x101d95440>
    └ <Timer(Thread-563, started daemon 123145560203264)>
  File "/Users/koen/miniconda3/envs/syftbox/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
    │    └ <function Timer.run at 0x101d96020>
    └ <Timer(Thread-563, started daemon 123145560203264)>
  File "/Users/koen/miniconda3/envs/syftbox/lib/python3.12/threading.py", line 1433, in run
    self.function(*self.args, **self.kwargs)
    │    │         │    │       │    └ {}
    │    │         │    │       └ <Timer(Thread-563, started daemon 123145560203264)>
    │    │         │    └ []
    │    │         └ <Timer(Thread-563, started daemon 123145560203264)>
    │    └ <bound method ResettableTimer._run_callback of <syftbox.lib.lib.ResettableTimer object at 0x1049832f0>>
    └ <Timer(Thread-563, started daemon 123145560203264)>

  File "/Users/koen/workspace/syft/syftbox/lib/lib.py", line 441, in _run_callback
    self.callback(*self.args, **self.kwargs)
    │    │         │    │       │    └ {'shared_state': <syftbox.lib.lib.SharedState object at 0x103ae99a0>}
    │    │         │    │       └ <syftbox.lib.lib.ResettableTimer object at 0x1049832f0>
    │    │         │    └ ()
    │    │         └ <syftbox.lib.lib.ResettableTimer object at 0x1049832f0>
    │    └ <function do_sync at 0x10492bba0>
    └ <syftbox.lib.lib.ResettableTimer object at 0x1049832f0>

  File "/Users/koen/workspace/syft/syftbox/client/plugins/sync.py", line 692, in do_sync
    num_changes += sync_down(shared_state.client_config)
    │              │         │            └ Client(config_path='/Users/koen/.syftbox/client_config.json', sync_folder='/Users/koen/Desktop/SyftBox2', port=8080, email='k...
    │              │         └ <syftbox.lib.lib.SharedState object at 0x103ae99a0>
    │              └ <function sync_down at 0x10492bb00>
    └ 0

  File "/Users/koen/workspace/syft/syftbox/client/plugins/sync.py", line 578, in sync_down
    remote_dir_state = get_remote_state(client_config, datasite)
                       │                │              └ 'andrej@jovanovic.co.za'
                       │                └ Client(config_path='/Users/koen/.syftbox/client_config.json', sync_folder='/Users/koen/Desktop/SyftBox2', port=8080, email='k...
                       └ <function get_remote_state at 0x10492b740>

> File "/Users/koen/workspace/syft/syftbox/client/plugins/sync.py", line 359, in get_remote_state
    raise e
          └ JSONDecodeError('Expecting value: line 1 column 1 (char 0)')

  File "/Users/koen/workspace/syft/syftbox/client/plugins/sync.py", line 356, in get_remote_state
    state_response = response.json()
                     │        └ <function Response.json at 0x10269d6c0>
                     └ <Response [500 Internal Server Error]>

  File "/Users/koen/miniconda3/envs/syftbox/lib/python3.12/site-packages/httpx/_models.py", line 766, in json
    return jsonlib.loads(self.content, **kwargs)
           │       │     │    │          └ {}
           │       │     │    └ <property object at 0x1026950d0>
           │       │     └ <Response [500 Internal Server Error]>
           │       └ <function loads at 0x1023e6de0>
           └ <module 'json' from '/Users/koen/miniconda3/envs/syftbox/lib/python3.12/json/__init__.py'>
  File "/Users/koen/miniconda3/envs/syftbox/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           │                │      └ 'Internal Server Error'
           │                └ <function JSONDecoder.decode at 0x1023e67a0>
           └ <json.decoder.JSONDecoder object at 0x101ea28d0>
  File "/Users/koen/miniconda3/envs/syftbox/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               │    │          │      │  └ 'Internal Server Error'
               │    │          │      └ <built-in method match of re.Pattern object at 0x1023f42b0>
               │    │          └ 'Internal Server Error'
               │    └ <function JSONDecoder.raw_decode at 0x1023e6840>
               └ <json.decoder.JSONDecoder object at 0x101ea28d0>
  File "/Users/koen/miniconda3/envs/syftbox/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
          │                                  └ 'Internal Server Error'
          └ <class 'json.decoder.JSONDecodeError'>

json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
2024-10-17 13:27:00.406 | INFO     | plugins.sync:sync_down:656 - ⏬ Syncing Down 2 Changes
├──koen2@syftbox.dev/app_pipelines/ring/running
└──koen2@syftbox.dev/app_pipelines/ring/done

/dir_state response Not JSON: Internal Server Error
```

we get

```
2024-10-17 13:39:49.816 | ERROR    | plugins.sync:get_remote_state:358 - Failed to call /dir_state for andrej@jovanovic.co.za response Not JSON: Internal Server Error this may be related to broken (empty!) syftperm files
2024-10-17 13:39:49.816 | INFO     | plugins.sync:sync_down:581 - Could not find remote state for andrej@jovanovic.co.za, skipping syncing down
```