### PR TITLE
FIX  starter_app 

### DIFF
--- a/default_apps/starter_app/main.py
+++ b/default_apps/starter_app/main.py
@@ -4,14 +4,17 @@ import shutil
 from pathlib import Path
 import os
 
-# Load the JSON data from a file
-with open("default_apps.json", "r") as file:
-    repo_urls = json.load(file)
+default_apps = [
+    "https://github.com/OpenMined/ring",
+    "https://github.com/OpenMined/github_app_updater",
+    "https://github.com/OpenMined/logged_in",
+]
 
 
 def clone_apps():
+    global default_apps
     # Iterate over the list and clone each repository
-    for url in repo_urls:
+    for url in default_apps:
         subprocess.run(["git", "clone", url])
 
 


### PR DESCRIPTION
## Description
Due to synchronization issues, the default_apps.json file in the syftbox/apps folder is not being loaded, which breaks the starter_app and prevents it from retrieving the default applications. To resolve this, I moved the list of default apps directly into main.py, allowing it to function independently of whether default_apps.json exists.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Init a new Syftbox client
- Wait for starter_app to run
- Check if the default_apps were installed in /apps

## Related ticket:
OpenMined/syft-internal-issues#134
