### PR TITLE
implement sync exit on fatal error

### DIFF
--- a/syftbox/client/plugins/sync/exceptions.py
+++ b/syftbox/client/plugins/sync/exceptions.py
@@ -1,0 +1,10 @@
+class FatalSyncError(Exception):
+    """Base exception to signal sync should be interrupted."""
+
+    pass
+
+
+class SyncEnvironmentError(FatalSyncError):
+    """the sync environment is corrupted (e.g. sync folder deleted), syncing cannot continue."""
+
+    pass

--- a/syftbox/server/sync/models.py
+++ b/syftbox/server/sync/models.py
@@ -82,6 +82,10 @@ class FileMetadata(BaseModel):
     def hash_bytes(self) -> bytes:
         return base64.b85decode(self.hash)
 
+    @property
+    def datasite_name(self) -> str:
+        return self.path.parts[0]
+
     def __eq__(self, value: Any):
         if not isinstance(value, FileMetadata):
             return False


### PR DESCRIPTION
## Description
Closes https://github.com/OpenMined/syft-internal-issues/issues/103

Stops the sync manager if something happens to the sync folder. Does not close syftbox, other plugins will keep running.

Fatal errors: 
- previous state is deleted or corrupted
- sync folder is deleted

![image](https://github.com/user-attachments/assets/9912a946-30d2-4730-b88e-f6ffbad72bfc)


## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
