### PR TITLE
Replace rprint.info to rprint since rprint.info doesn't seems to exist

### DIFF
--- a/syftbox/client/cli_setup.py
+++ b/syftbox/client/cli_setup.py
@@ -44,7 +44,7 @@ def get_migration_decision(data_dir: Path):
             # 1. determine if we want to remove
             # 2. determine if we want to migrate
             if prompt_delete_old_data_dir(data_dir):
-                rprint.info("Removing old syftbox folder")
+                rprint("Removing old syftbox folder")
                 shutil.rmtree(str(data_dir))
                 migrate_datasite = False
             else:


### PR DESCRIPTION
## Description
In cli_setup.py, we were calling for a method `rprint.info` which doens't seems to exist. This PR aims to fix this small issue.


## How to reproduce the issue:
- call `just rc <user> 8081`
- stop the syftbox client
- call `just rc <user> 8081` again
- You might me able to see a cli message saying that .clients folder already  exists. type `'y'`
- The exception about rprint not having a function called .info might happen.
