### PR TITLE
sync dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pydantic[email]>=2.9.2",
     "ruamel-yaml>=0.18.6",
     "pyjwt>=2.10.0",
+    "wcmatch>=10.0",
 ]
 
 [project.optional-dependencies]

--- a/syftbox/assets/templates/sync_dashboard.jinja2
+++ b/syftbox/assets/templates/sync_dashboard.jinja2
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Sync Dashboard</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            margin: 20px;
+            line-height: 1.6;
+            background-color: #f8f9fa;
+            color: #333;
+        }
+        h1 {
+            margin-bottom: 30px;
+            color: #1a1a1a;
+        }
+        .search-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+            background: white;
+            padding: 16px;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .search-box {
+            display: flex;
+            gap: 10px;
+        }
+        #search {
+            padding: 8px 12px;
+            width: 300px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 14px;
+        }
+        .refresh-button {
+            padding: 8px 16px;
+            background-color: #fff;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: all 0.2s;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .refresh-button:hover {
+            background-color: #f5f5f5;
+        }
+        .refresh-button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+        .refresh-button .spinner {
+            display: none;
+            width: 12px;
+            height: 12px;
+            border: 2px solid #ccc;
+            border-top-color: #666;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+        .refresh-button.loading .spinner {
+            display: inline-block;
+        }
+        .refresh-button.loading .refresh-icon {
+            display: none;
+        }
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            background: white;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            position: relative;
+        }
+        .table-overlay {
+            display: none;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(255, 255, 255, 0.8);
+            justify-content: center;
+            align-items: center;
+        }
+        .table-overlay.visible {
+            display: flex;
+        }
+        th, td {
+            text-align: left;
+            padding: 12px 16px;
+            border-bottom: 1px solid #eee;
+        }
+        th {
+            background-color: #fff;
+            font-weight: 600;
+            color: #666;
+        }
+        td {
+            font-size: 14px;
+        }
+        .label {
+            border-radius: 4px;
+            padding: 6px 8px;
+            white-space: nowrap;
+            overflow: hidden;
+            line-height: 1.2;
+            font-family: monospace;
+            text-transform: uppercase;
+            display: inline-block;
+            font-size: 12px;
+        }
+        .label-green {
+            background-color: #d5f1d5;
+            color: #256b24;
+        }
+        .label-red {
+            background-color: #f2d9de;
+            color: #9b2737;
+        }
+        .label-orange {
+            background-color: #fee9cd;
+            color: #b8520a;
+        }
+        .label-gray {
+            background-color: #ecebef;
+            color: #353243;
+        }
+        .label-remote {
+            background-color: #e0f2ff;
+            color: #0969da;
+        }
+        .label-local {
+            background-color: #ddf4ff;
+            color: #0550ae;
+        }
+        .error-message {
+            display: none;
+            background-color: #f2d9de;
+            color: #9b2737;
+            padding: 12px;
+            border-radius: 4px;
+            margin-bottom: 16px;
+        }
+        .error-message.visible {
+            display: block;
+        }
+
+        .dev-banner {
+            background-color: #f2d9de;
+            color: #9b2737;
+            padding: 12px 20px;
+            margin: -20px -20px 20px -20px;
+            text-align: center;
+            font-weight: 500;
+        }
+    </style>
+</head>
+<body>
+    <div class="dev-banner">
+        This dashboard is for development purposes only, and is not intended for production use.
+    </div>
+    <h1>Sync Dashboard</h1>
+
+    <div id="error-container" class="error-message"></div>
+
+    <div class="search-container">
+        <div class="search-box">
+            <input
+                type="text"
+                id="search"
+                placeholder="Search paths..."
+                oninput="debounceSearch(event)"
+                autocomplete="off"
+            >
+            <button id="refresh-button" class="refresh-button" onclick="refreshData()">
+                <span class="spinner"></span>
+                <span class="refresh-icon">↻</span>
+                Refresh
+            </button>
+        </div>
+        <div>
+            Total results: <span id="result-count">0</span>
+        </div>
+    </div>
+
+    <div style="position: relative;">
+        <table>
+            <thead>
+                <tr>
+                    <th>Path</th>
+                    <th>Date</th>
+                    <th>Status</th>
+                    <th>Message</th>
+                    <th>Action</th>
+                </tr>
+            </thead>
+            <tbody id="table-body">
+            </tbody>
+        </table>
+        <div id="table-overlay" class="table-overlay">
+            <div class="spinner"></div>
+        </div>
+    </div>
+
+    <script>
+        const BASE_URL = "{{ base_url }}".replace(/\/$/, '');
+        let isLoading = false;
+        let searchDebounceTimeout = null;
+
+        function getStatusClass(status) {
+            switch(status.toLowerCase()) {
+                case 'synced': return 'label-green';
+                case 'error': return 'label-red';
+                case 'queued': return 'label-orange';
+                case 'ignored': return 'label-gray';
+                default: return 'label-gray';
+            }
+        }
+
+        function getActionClass(action) {
+            if (!action) return '';
+            return action.includes('_REMOTE') ? 'label-remote' : 'label-local';
+        }
+
+        function formatDate(dateStr) {
+            const date = new Date(dateStr);
+            return date.toLocaleString();
+        }
+
+        function setLoading(loading) {
+            isLoading = loading;
+            const button = document.getElementById('refresh-button');
+            const overlay = document.getElementById('table-overlay');
+
+            button.disabled = loading;
+            button.classList.toggle('loading', loading);
+            overlay.classList.toggle('visible', loading);
+        }
+
+        function showError(message) {
+            const container = document.getElementById('error-container');
+            container.textContent = message;
+            container.classList.add('visible');
+        }
+
+        function hideError() {
+            const container = document.getElementById('error-container');
+            container.classList.remove('visible');
+        }
+
+        function renderTable(items) {
+            const tbody = document.getElementById('table-body');
+            tbody.innerHTML = items.map(item => `
+                <tr>
+                    <td>${item.path}</td>
+                    <td>${formatDate(item.timestamp)}</td>
+                    <td><span class="label ${getStatusClass(item.status)}">${item.status}</span></td>
+                    <td>${item.message || ''}</td>
+                    <td>${item.action ? `<span class="label ${getActionClass(item.action)}">${item.action}</span>` : ''}</td>
+                </tr>
+            `).join('');
+
+            document.getElementById('result-count').textContent = items.length;
+        }
+
+        function debounceSearch(event) {
+            if (searchDebounceTimeout) {
+                clearTimeout(searchDebounceTimeout);
+            }
+            searchDebounceTimeout = setTimeout(() => {
+                refreshData();
+            }, 300); // 300ms debounce delay
+        }
+
+        async function refreshData() {
+            if (isLoading) return;
+
+            hideError();
+            setLoading(true);
+
+            try {
+                const searchTerm = document.getElementById('search').value;
+
+                let filters = [];
+                if (searchTerm) {
+                    filters.push({
+                        field: "path",
+                        op: "glob",
+                        value: searchTerm
+                    });
+                }
+
+                const response = await fetch(`${BASE_URL}/sync/list_status_info`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        order_by: "timestamp",
+                        order: "desc",
+                        filters: filters
+                    })
+                });
+
+                if (response.ok) {
+                    const data = await response.json();
+                    renderTable(data);
+                } else {
+                    const error = await response.text();
+                    throw new Error(`Failed to fetch data: ${error}`);
+                }
+            } catch (error) {
+                console.error('Error:', error);
+                showError(`Failed to load data: ${error.message}`);
+                renderTable([]);  // Clear the table on error
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        // Initial load
+        refreshData();
+    </script>
+</body>
+</html>

--- a/syftbox/assets/templates/sync_dashboard.jinja2
+++ b/syftbox/assets/templates/sync_dashboard.jinja2
@@ -156,12 +156,16 @@
         }
 
         .dev-banner {
-            background-color: #f2d9de;
-            color: #9b2737;
-            padding: 12px 20px;
+            background-color: #ef5350;
+            color: rgba(255, 255, 255, 0.95);
+            padding: 8px 20px;
             margin: -20px -20px 20px -20px;
             text-align: center;
-            font-weight: 500;
+            font-weight: 400;
+            font-size: 14px;
+            letter-spacing: 0.3px;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
         }
     </style>
 </head>
@@ -290,26 +294,17 @@
 
             try {
                 const searchTerm = document.getElementById('search').value;
+                const params = new URLSearchParams({
+                    order_by: "timestamp",
+                    order: "desc"
+                });
 
-                let filters = [];
                 if (searchTerm) {
-                    filters.push({
-                        field: "path",
-                        op: "glob",
-                        value: searchTerm
-                    });
+                    params.append('path_glob', searchTerm);
                 }
 
-                const response = await fetch(`${BASE_URL}/sync/list_status_info`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({
-                        order_by: "timestamp",
-                        order: "desc",
-                        filters: filters
-                    })
+                const response = await fetch(`${BASE_URL}/sync/state?${params}`, {
+                    method: 'GET',
                 });
 
                 if (response.ok) {

--- a/syftbox/client/api.py
+++ b/syftbox/client/api.py
@@ -25,16 +25,30 @@ async def lifespan(app: FastAPI):
 def create_api(client: SyftClientInterface) -> FastAPI:
     app = FastAPI(lifespan=lifespan)
 
+    allow_origins = [
+        "http://localhost",
+        "http://localhost:5001",
+        "http://localhost:8080",
+        "http://localhost:8081",
+        "http://localhost:8083",
+        "https://syftbox.openmined.org",
+    ]
+    port = client.config.client_url.port
+    if port:
+        allow_origins.extend(
+            [
+                f"http://localhost:{port}",
+                f"http://127.0.0.1:{port}",
+                f"http://localhost:{port}/",
+                f"http://127.0.0.1:{port}/",
+            ]
+        )
+
+    print(f"Allowing origins: {allow_origins}")
+
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=[
-            "http://localhost",
-            "http://localhost:5001",
-            "http://localhost:8080",
-            "http://localhost:8081",
-            "http://localhost:8083",
-            "https://syftbox.openmined.org",
-        ],  # Allow localhost on any port and specific domain
+        allow_origins=allow_origins,
         allow_credentials=True,
         allow_methods=["*"],  # Allow all HTTP methods
         allow_headers=["*"],  # Allow all headers

--- a/syftbox/client/api.py
+++ b/syftbox/client/api.py
@@ -35,6 +35,7 @@ def create_api(client: SyftClientInterface) -> FastAPI:
     ]
     port = client.config.client_url.port
     if port:
+        # Allow origins for client localhost client API
         allow_origins.extend(
             [
                 f"http://localhost:{port}",
@@ -43,8 +44,6 @@ def create_api(client: SyftClientInterface) -> FastAPI:
                 f"http://127.0.0.1:{port}/",
             ]
         )
-
-    print(f"Allowing origins: {allow_origins}")
 
     app.add_middleware(
         CORSMiddleware,

--- a/syftbox/client/plugins/sync/consumer.py
+++ b/syftbox/client/plugins/sync/consumer.py
@@ -463,11 +463,14 @@ class SyncConsumer:
             return
         else:
             # Not executed and not NOOP means there was an error. Log error to local state
-            message = decisions.local_decision.message or decisions.remote_decision.message
+            decision = decisions.local_decision if not decisions.local_decision.is_noop() else decisions.remote_decision
+            action = decision.action_type
+            message = decision.message
             self.local_state.insert_status_info(
                 path=item.data.path,
                 status=SyncStatus.ERROR,
                 message=message,
+                action=action,
             )
 
     def process_filechange(self, item: SyncQueueItem) -> None:

--- a/syftbox/client/plugins/sync/local_state.py
+++ b/syftbox/client/plugins/sync/local_state.py
@@ -68,9 +68,7 @@ class LocalState(BaseModel):
     ):
         if not isinstance(path, Path):
             raise ValueError(f"path must be a Path object, got {path}")
-        self.status_info[path] = SyncStatusInfo(
-            path=path, timestamp=datetime.now(), status=status, message=message, action=action
-        )
+        self.status_info[path] = SyncStatusInfo(path=path, status=status, message=message, action=action)
         if save:
             self.save()
 

--- a/syftbox/client/plugins/sync/manager.py
+++ b/syftbox/client/plugins/sync/manager.py
@@ -57,6 +57,8 @@ class SyncManager:
                 except FatalSyncError as e:
                     logger.error(f"Syncing encountered a fatal error. {e}")
                     break
+                except Exception as e:
+                    logger.error(f"Syncing encountered an error: {e}. Retrying in {manager.sync_interval} seconds.")
 
         self.is_stop_requested = False
         t = Thread(target=_start, args=(self,), daemon=True)

--- a/syftbox/client/plugins/sync/queue.py
+++ b/syftbox/client/plugins/sync/queue.py
@@ -1,5 +1,6 @@
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from queue import PriorityQueue
 from typing import Dict, Optional
@@ -11,6 +12,7 @@ from syftbox.client.plugins.sync.types import FileChangeInfo
 class SyncQueueItem:
     priority: int
     data: FileChangeInfo
+    enqueued_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
 
 
 class SyncQueue:

--- a/syftbox/client/plugins/sync/types.py
+++ b/syftbox/client/plugins/sync/types.py
@@ -10,6 +10,7 @@ from syftbox.lib.lib import SyftPermission
 
 
 class SyncStatus(str, Enum):
+    QUEUED = "queued"
     SYNCED = "synced"
     ERROR = "error"
     IGNORED = "ignored"

--- a/syftbox/client/routers/sync_router.py
+++ b/syftbox/client/routers/sync_router.py
@@ -1,20 +1,70 @@
-from typing import List
+from enum import Enum
+from pathlib import Path
+from typing import Any, List, Optional
 
-from fastapi import APIRouter, HTTPException
-from loguru import logger
+import wcmatch
+import wcmatch.fnmatch
+import wcmatch.glob
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import HTMLResponse
+from jinja2 import Environment, FileSystemLoader
+from pydantic import BaseModel
 
-from syftbox.client.plugins.sync.local_state import LocalState, SyncStatusInfo
+from syftbox.client.exceptions import SyftPluginException
+from syftbox.client.plugins.sync.local_state import SyncStatusInfo
+from syftbox.client.plugins.sync.manager import SyncManager
+from syftbox.client.plugins.sync.types import SyncStatus
 from syftbox.client.routers.common import APIContext
 
 router = APIRouter()
+jinja_env = Environment(loader=FileSystemLoader("syftbox/assets/templates"))
 
 
-@router.get("/data")
-def get_sync_data(
-    context: APIContext,
-    order_by: str = "timestamp",
-    order: str = "desc",
-) -> List[SyncStatusInfo]:
+def get_sync_manager(context: APIContext) -> SyncManager:
+    try:
+        return context.plugins.sync_manager
+    except SyftPluginException as e:
+        raise HTTPException(status_code=500, detail=f"Failed to get sync manager: {e}")
+
+
+def _get_queued_items(sync_manager: SyncManager) -> List[SyncStatusInfo]:
+    # make copy to avoid changing size during iteration
+    queued_items = list(sync_manager.queue.all_items.values())
+    return [
+        SyncStatusInfo(
+            path=item.data.path,
+            status=SyncStatus.QUEUED,
+            timestamp=item.enqueued_at,
+        )
+        for item in queued_items
+    ]
+
+
+def _get_items_from_localstate(sync_manager: SyncManager) -> List[SyncStatusInfo]:
+    return list(sync_manager.local_state.status_info.values())
+
+
+def _get_all_status_info(sync_manager: SyncManager) -> List[SyncStatusInfo]:
+    """
+    Return all status info from both the queue and local state.
+    NOTE: the result might contain duplicates if the same path is present in both.
+    """
+    queued_items = _get_queued_items(sync_manager)
+    localstate_items = _get_items_from_localstate(sync_manager)
+    return queued_items + localstate_items
+
+
+def _deduplicate_status_info(status_info_list: List[SyncStatusInfo]) -> List[SyncStatusInfo]:
+    """Deduplicate status info by path, keeping the entry with latest timestamp"""
+    path_to_info = {}
+    for info in status_info_list:
+        existing_info = path_to_info.get(info.path)
+        if not existing_info or info.timestamp > existing_info.timestamp:
+            path_to_info[info.path] = info
+    return list(path_to_info.values())
+
+
+def _sort_status_info(status_info_list: List[SyncStatusInfo], order_by: str, order: str) -> List[SyncStatusInfo]:
     if order_by.lower() not in SyncStatusInfo.model_fields:
         raise HTTPException(
             status_code=400,
@@ -23,15 +73,103 @@ def get_sync_data(
     if order.lower() not in ["asc", "desc"]:
         raise HTTPException(status_code=400, detail=f"Invalid order: {order}, expected 'asc' or 'desc'")
 
-    sync_state = LocalState.for_client(context)
-    if not sync_state.file_path.is_file():
-        logger.error(f"LocalState file not found: {sync_state.file_path}")
-        return []
-    sync_state.load()
-    logger.info(f"Loaded sync state: {sync_state.file_path}, with {len(sync_state.status_info)} entries")
-
-    return sorted(
-        sync_state.status_info.values(),
-        key=lambda x: getattr(x, order_by),
-        reverse=order.lower() == "desc",
+    return list(
+        sorted(
+            status_info_list,
+            key=lambda x: getattr(x, order_by),
+            reverse=order.lower() == "desc",
+        )
     )
+
+
+class FilterOperator(str, Enum):
+    eq = "eq"
+    ne = "ne"
+    lt = "lt"
+    gt = "gt"
+    le = "le"
+    ge = "ge"
+    glob = "glob"
+
+
+def _evaluate_glob(value: Any, pattern: str) -> bool:
+    # NOTE using fnmatch instead of glob to support basic patterns like "*.txt"
+    if not isinstance(value, (Path, str)):
+        return False
+    return wcmatch.fnmatch.fnmatch(
+        value.as_posix(),
+        pattern,
+    )
+
+
+class FilterCondition(BaseModel):
+    field: str
+    op: FilterOperator
+    value: Any
+
+    def evaluate(self, item: Any) -> bool:
+        """Return True if the item's field value satisfies the condition, False otherwise"""
+        try:
+            value = getattr(item, self.field)
+            if self.op == FilterOperator.eq:
+                return value == self.value
+            elif self.op == FilterOperator.ne:
+                return value != self.value
+            elif self.op == FilterOperator.lt:
+                return value < self.value
+            elif self.op == FilterOperator.gt:
+                return value > self.value
+            elif self.op == FilterOperator.le:
+                return value <= self.value
+            elif self.op == FilterOperator.ge:
+                return value >= self.value
+            elif self.op == FilterOperator.glob:
+                return _evaluate_glob(value, self.value)
+            else:
+                return False
+        except Exception:
+            # Failing comparisons always return False
+            return False
+
+
+def _apply_filter(status_info_list: List[SyncStatusInfo], condition: FilterCondition) -> List[SyncStatusInfo]:
+    if condition.field not in SyncStatusInfo.model_fields:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid filter field: {condition.field}. Available fields: {list(SyncStatusInfo.model_fields.keys())}",
+        )
+    return [item for item in status_info_list if condition.evaluate(item)]
+
+
+def _filter_status_info(items: List[SyncStatusInfo], filters: Optional[List[FilterCondition]]) -> List[SyncStatusInfo]:
+    if not filters:
+        return items
+
+    result = items
+    for condition in filters:
+        result = _apply_filter(result, condition)
+    return result
+
+
+class ListStatusInfoRequest(BaseModel):
+    order_by: str = "timestamp"
+    order: str = "desc"
+    filters: Optional[List[FilterCondition]] = None
+
+
+@router.post("/list_status_info")
+def get_status_info(
+    request: ListStatusInfoRequest,
+    sync_manager: SyncManager = Depends(get_sync_manager),
+) -> List[SyncStatusInfo]:
+    all_items = _get_all_status_info(sync_manager)
+    items_deduplicated = _deduplicate_status_info(all_items)
+    items_filtered = _filter_status_info(items_deduplicated, request.filters)
+    items_sorted = _sort_status_info(items_filtered, request.order_by, request.order)
+    return items_sorted
+
+
+@router.get("/")
+def sync_dashboard(context: APIContext):
+    template = jinja_env.get_template("sync_dashboard.jinja2")
+    return HTMLResponse(template.render(base_url=context.config.client_url))

--- a/tests/unit/client/api_test.py
+++ b/tests/unit/client/api_test.py
@@ -3,9 +3,18 @@ from fastapi.testclient import TestClient
 
 from syftbox.client.api import create_api
 from syftbox.client.base import SyftClientInterface
+from syftbox.lib.client_config import SyftClientConfig
 
 
 class MockClient(SyftClientInterface):
+    def __init__(self):
+        self.config = SyftClientConfig(
+            path="/tmp/syftbox/config.yaml",
+            client_url="http://localhost:8080",
+            server_url="http://localhost:5000",
+            email="test@user.com",
+        )
+
     @property
     def all_datasites(self):
         return ["datasite1", "datasite2"]
@@ -13,7 +22,7 @@ class MockClient(SyftClientInterface):
 
 @pytest.fixture
 def mock_api():
-    yield TestClient(create_api({}))
+    yield TestClient(create_api(MockClient()))
 
 
 def test_create_api(mock_api):
@@ -33,8 +42,3 @@ def test_datasites():
     response = mock_api.get("/datasites")
     assert response.status_code == 200
     assert response.json() == {"datasites": ["datasite1", "datasite2"]}
-
-
-def test_datasites_exception(mock_api):
-    response = mock_api.get("/datasites")
-    assert response.status_code == 500

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.5.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/6c/57418c4404cd22fe6275b8301ca2b46a8cdaa8157938017a9ae0b3edf363/bracex-2.5.post1.tar.gz", hash = "sha256:12c50952415bfa773d2d9ccb8e79651b8cdb1f31a42f6091b804f6ba2b4a66b6", size = 26641 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/02/8db98cdc1a58e0abd6716d5e63244658e6e63513c65f469f34b6f1053fd0/bracex-2.5.post1-py3-none-any.whl", hash = "sha256:13e5732fec27828d6af308628285ad358047cec36801598368cb28bc631dbaf6", size = 11558 },
+]
+
+[[package]]
 name = "brotli"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1446,6 +1455,8 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/c7/8c6872f7372eb6a6b2e4708b88419fb46b857f7a2e1892966b851cc79fc9/psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2", size = 508067 }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/66/78c9c3020f573c58101dc43a44f6855d01bbbd747e24da2f0c4491200ea3/psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35", size = 249766 },
+    { url = "https://files.pythonhosted.org/packages/e1/3f/2403aa9558bea4d3854b0e5e567bc3dd8e9fbc1fc4453c0aa9aafeb75467/psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1", size = 253024 },
     { url = "https://files.pythonhosted.org/packages/0b/37/f8da2fbd29690b3557cca414c1949f92162981920699cd62095a984983bf/psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0", size = 250961 },
     { url = "https://files.pythonhosted.org/packages/35/56/72f86175e81c656a01c4401cd3b1c923f891b31fbcebe98985894176d7c9/psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0", size = 287478 },
     { url = "https://files.pythonhosted.org/packages/19/74/f59e7e0d392bc1070e9a70e2f9190d652487ac115bb16e2eff6b22ad1d24/psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd", size = 290455 },
@@ -2170,6 +2181,7 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn" },
     { name = "watchdog" },
+    { name = "wcmatch" },
 ]
 
 [package.dev-dependencies]
@@ -2213,6 +2225,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "uvicorn", specifier = ">=0.30.6" },
     { name = "watchdog", specifier = ">=5.0.2" },
+    { name = "wcmatch", specifier = ">=10.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2371,6 +2384,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/69/cfb2d17ba8aabc73be2e2d03c8c319b1f32053a02c4b571852983aa24ff2/watchdog-5.0.3-py3-none-win32.whl", hash = "sha256:c66f80ee5b602a9c7ab66e3c9f36026590a0902db3aea414d59a2f55188c1f49", size = 79320 },
     { url = "https://files.pythonhosted.org/packages/91/b4/2b5b59358dadfa2c8676322f955b6c22cde4937602f40490e2f7403e548e/watchdog-5.0.3-py3-none-win_amd64.whl", hash = "sha256:f00b4cf737f568be9665563347a910f8bdc76f88c2970121c86243c8cfdf90e9", size = 79325 },
     { url = "https://files.pythonhosted.org/packages/38/b8/0aa69337651b3005f161f7f494e59188a1d8d94171666900d26d29d10f69/watchdog-5.0.3-py3-none-win_ia64.whl", hash = "sha256:49f4d36cb315c25ea0d946e018c01bb028048023b9e103d3d3943f58e109dd45", size = 79324 },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/ab/b3a52228538ccb983653c446c1656eddf1d5303b9cb8b9aef6a91299f862/wcmatch-10.0.tar.gz", hash = "sha256:e72f0de09bba6a04e0de70937b0cf06e55f36f37b3deb422dfaf854b867b840a", size = 115578 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/df/4ee467ab39cc1de4b852c212c1ed3becfec2e486a51ac1ce0091f85f38d7/wcmatch-10.0-py3-none-any.whl", hash = "sha256:0dd927072d03c0a6527a20d2e6ad5ba8d0380e60870c383bc533b71744df7b7a", size = 39347 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

- Add simple webpage
- Add sync state endpoint, example: `/sync/state?path_glob=**/*.txt&order_by=path&order=asc`
- Get sync status info directly from SyncManager instead of reading local_state file
- update client CORS policy to include client localhost urls

example:
![image](https://github.com/user-attachments/assets/c83172fa-2cd8-4c60-9d05-5c3cb689c0dd)


TODO 
- occasionally symlinked files are included even though they are filtered out: https://github.com/OpenMined/syft-internal-issues/issues/226
- Probably need more functionality on /sync/state endpoint if its used in apps (like filtering on status)

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
