### PR TITLE
Require authenticated user for app install logging

### DIFF
--- a/syftbox/lib/debug.py
+++ b/syftbox/lib/debug.py
@@ -25,7 +25,7 @@ def debug_report(config_path: Optional[PathLike] = None) -> str:
         result = list_app(workspace)
         app_dir = result.apps_dir
         apps = [app.name for app in result.apps]
-        client_config = client_config.as_dict(exclude={"token"})
+        client_config = client_config.as_dict(exclude={"token", "access_token"})
     except Exception as e:
         logger.exception("Error loading client config", e)
         pass

--- a/syftbox/server/server.py
+++ b/syftbox/server/server.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-from fastapi import Depends, FastAPI, Header, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import (
     FileResponse,
@@ -30,6 +30,7 @@ from syftbox.server.analytics import log_analytics_event
 from syftbox.server.logger import setup_logger
 from syftbox.server.middleware import LoguruMiddleware
 from syftbox.server.settings import ServerSettings, get_server_settings
+from syftbox.server.users.auth import get_current_user
 
 from .emails.router import router as emails_router
 from .sync import db, hash
@@ -339,7 +340,10 @@ async def register(
 
 
 @app.post("/log_event")
-async def log_event(request: Request, email: Optional[str] = Header(default=None)):
+async def log_event(
+    request: Request,
+    email: str = Depends(get_current_user),
+):
     data = await request.json()
     log_analytics_event("/log_event", email, **data)
     return JSONResponse({"status": "success"}, status_code=200)


### PR DESCRIPTION
## Description

Server was not checking for auth token on logging client-side analytics events, which was causing logs from developers ending up in server analytics. This PR fixes it, unauthenticated analytics events will now return a 401, which is ignored by the install CLI.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
