### PR TITLE
Check client version on startup + log user OS to analytics

### DIFF
--- a/syftbox/client/auth.py
+++ b/syftbox/client/auth.py
@@ -80,14 +80,12 @@ def get_access_token(
         return get_access_token(conf, auth_client)
     else:
         rprint(f"[red]An unexpected error occurred: {response.text}[/red]")
-        typer.Exit(1)
+        raise typer.Exit(1)
 
 
-def authenticate_user(conf: SyftClientConfig) -> str:
-    auth_client = httpx.Client(base_url=str(conf.server_url))
-
-    if has_valid_access_token(conf, auth_client):
+def authenticate_user(conf: SyftClientConfig, login_client: httpx.Client) -> str:
+    if has_valid_access_token(conf, login_client):
         return conf.access_token
 
-    email_token = request_email_token(auth_client, conf)
-    return get_access_token(conf, auth_client, email_token)
+    email_token = request_email_token(login_client, conf)
+    return get_access_token(conf, login_client, email_token)

--- a/syftbox/client/cli.py
+++ b/syftbox/client/cli.py
@@ -112,7 +112,10 @@ def client(
 
     log_level = "DEBUG" if verbose else "INFO"
     code = run_client(
-        client_config=client_config, open_dir=open_dir, log_level=log_level, migrate_datasite=migrate_datasite
+        client_config=client_config,
+        open_dir=open_dir,
+        log_level=log_level,
+        migrate_datasite=migrate_datasite,
     )
     raise Exit(code)
 

--- a/syftbox/client/cli_setup.py
+++ b/syftbox/client/cli_setup.py
@@ -164,13 +164,14 @@ def verify_installation(conf: SyftClientConfig, client: httpx.Client) -> None:
         response = client.get("/info")
         response.raise_for_status()
         server_info = response.json()
-        local_version = "0.0.1"
+        server_version = server_info["version"]
+        local_version = __version__
 
-        if server_info["version"] == local_version:
+        if server_version == local_version:
             return
 
         should_continue = Confirm.ask(
-            f"\n[yellow]Server version ({server_info['version']}) does not match your client version ({local_version}).\n"
+            f"\n[yellow]Server version ({server_version}) does not match your client version ({local_version}).\n"
             f"[bold](recommended)[/bold] To update, run:\n\n"
             f"[bold]curl -LsSf https://syftbox.openmined.org/install.sh | sh[/bold][/yellow]\n\n"
             f"Continue without updating?"

--- a/syftbox/client/client2.py
+++ b/syftbox/client/client2.py
@@ -186,6 +186,18 @@ class SyftClient:
         if platform.system() == "Darwin":
             macos.copy_icon_file(ICON_FOLDER, self.workspace.data_dir)
 
+    def log_system_info(self):
+        self.server_client.post(
+            "/log_event",
+            json={
+                "event_name": "system_info",
+                "os_name": "macOS" if platform.system() == "Darwin" else platform.system(),
+                "os_version": platform.release(),
+                "syftbox_version": __version__,
+                "python_version": platform.python_version(),
+            },
+        )
+
     def __enter__(self):
         return self
 
@@ -318,6 +330,7 @@ def run_client(
         bool(client.check_pidfile()) and run_migration(client_config, migrate_datasite=migrate_datasite)
         (not syftbox_env.DISABLE_ICONS) and client.copy_icons()
         open_dir and client.open_datasites_dir()
+        client.log_system_info()
         client.start()
     except SyftBoxAlreadyRunning as e:
         logger.error(e)

--- a/syftbox/client/client2.py
+++ b/syftbox/client/client2.py
@@ -17,6 +17,7 @@ from syftbox.client.exceptions import SyftBoxAlreadyRunning, SyftServerError
 from syftbox.client.logger import setup_logger
 from syftbox.client.plugin_manager import PluginManager
 from syftbox.client.utils import error_reporting, file_manager, macos
+from syftbox.client.utils.file_manager import _is_wsl
 from syftbox.lib.client_config import SyftClientConfig
 from syftbox.lib.datasite import create_datasite
 from syftbox.lib.exceptions import SyftBoxException
@@ -187,11 +188,17 @@ class SyftClient:
             macos.copy_icon_file(ICON_FOLDER, self.workspace.data_dir)
 
     def log_system_info(self):
+        if _is_wsl():
+            os_name = "WSL"
+        else:
+            os_name = platform.system()
+            os_name = "macOS" if os_name == "Darwin" else os_name
+
         self.server_client.post(
             "/log_event",
             json={
                 "event_name": "system_info",
-                "os_name": "macOS" if platform.system() == "Darwin" else platform.system(),
+                "os_name": os_name,
                 "os_version": platform.release(),
                 "syftbox_version": __version__,
                 "python_version": platform.python_version(),

--- a/tests/unit/client/setup_config_test.py
+++ b/tests/unit/client/setup_config_test.py
@@ -12,7 +12,13 @@ def test_setup_new_config(tmp_path):
     port = 8080
 
     result = setup_config_interactive(
-        config_path=config_path, email=email, data_dir=data_dir, server=server, port=port, skip_auth=True
+        config_path=config_path,
+        email=email,
+        data_dir=data_dir,
+        server=server,
+        port=port,
+        skip_auth=True,
+        skip_verify_install=True,
     )
 
     assert isinstance(result, SyftClientConfig)
@@ -41,6 +47,7 @@ def test_setup_new_config_with_prompt(tmp_path, monkeypatch):
         server=server,
         port=port,
         skip_auth=True,
+        skip_verify_install=True,
     )
 
     assert isinstance(result, SyftClientConfig)
@@ -61,6 +68,7 @@ def test_setup_existing_config(tmp_path, mock_config):
         config_path=mock_config.path,
         port=new_port,
         skip_auth=True,
+        skip_verify_install=True,
     )
 
     assert isinstance(result, SyftClientConfig)


### PR DESCRIPTION
closes https://github.com/OpenMined/syft-internal-issues/issues/222

## Description
- on startup, compare client version and server version + ask if user wants to continue
example, 1st with hardcoded version and 2nd without running server:

![image](https://github.com/user-attachments/assets/dcb0ed90-f054-49b3-a1e2-dc561f297f51)

- log user system after login:

```
{
  "event_type": "analytics_event",
  "email": "test@user.com",
  "endpoint": "/log_event",
  "timestamp": "2024-11-28T15:18:05.080510+00:00",
  "event_name": "system_info",
  "os_name": "macOS",
  "os_version": "23.2.0",
  "syftbox_version": "0.2.11",
  "python_version": "3.12.6"
}
```

## TODO 
- https://github.com/OpenMined/syft-internal-issues/issues/229

