### PR TITLE
add path alias for file_path in LocalState

### DIFF
--- a/syftbox/client/plugins/sync/local_state.py
+++ b/syftbox/client/plugins/sync/local_state.py
@@ -24,7 +24,7 @@ class SyncStatusInfo(BaseModel):
 
 
 class LocalState(BaseModel):
-    file_path: Path = Field(description="Path to the LocalState file")
+    file_path: Path = Field(description="Path to the LocalState file", alias="path")
     # The state of files on last successful sync
     states: dict[Path, FileMetadata] = {}
     # The last sync status of each file
@@ -32,7 +32,7 @@ class LocalState(BaseModel):
 
     @classmethod
     def for_client(cls: Type[Self], client: SyftClientInterface) -> Self:
-        return cls(file_path=client.workspace.plugins / LOCAL_STATE_FILENAME)
+        return cls(path=client.workspace.plugins / LOCAL_STATE_FILENAME)
 
     def insert_synced_file(self, path: Path, state: FileMetadata, action: "SyncActionType") -> None:
         if not isinstance(path, Path):


### PR DESCRIPTION
## Description

Use `path` as alias for the new variable `file_path` in LocalState. This allows to initialise as LocalState(path="", ...), maintaining backward compatibility. Once the LocalState is saved, the `path` key in localsync_state.json is overridden to `file_path`. 

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
