### PR TITLE
Fix symlink race condition

### DIFF
--- a/syftbox/assets/templates/sync_dashboard.jinja2
+++ b/syftbox/assets/templates/sync_dashboard.jinja2
@@ -135,13 +135,14 @@
             background-color: #ecebef;
             color: #353243;
         }
-        .label-remote {
-            background-color: #e0f2ff;
-            color: #0969da;
+        .label-blue {
+            background-color: #d5e7ff;
+            color: #1a365d;
         }
-        .label-local {
-            background-color: #ddf4ff;
-            color: #0550ae;
+        .label-lightblue {
+            background-color: #e8f3ff;
+            color: #486b9e;
+        }
         }
         .error-message {
             display: none;
@@ -233,7 +234,7 @@
 
         function getActionClass(action) {
             if (!action) return '';
-            return action.includes('_REMOTE') ? 'label-remote' : 'label-local';
+            return action.includes('_REMOTE') ? 'label-blue' : 'label-lightblue';
         }
 
         function formatDate(dateStr) {

--- a/tests/unit/hash_test.py
+++ b/tests/unit/hash_test.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+from syftbox.client.utils.dir_tree import create_dir_tree
+from syftbox.server.sync.hash import collect_files
+
+
+def test_collect_files(tmp_path: Path):
+    # Create entire test structure including symlink targets
+    tree = {
+        # Symlink targets
+        "folder_to_symlink": {"file_in_symlink.txt": "symlink content"},
+        "file_to_symlink.txt": "symlink file content",
+        # Test structure
+        "test_dir": {
+            "file1.txt": "content1",
+            "file2.txt": "content2",
+            ".hidden_file": "hidden",
+            ".hidden_dir": {
+                "file_in_hidden.txt": "hidden content",
+            },
+            "nested": {
+                "nested_file.txt": "nested content",
+            },
+        },
+    }
+    create_dir_tree(tmp_path, tree)
+
+    # Create symlinks in test_dir
+    test_dir = tmp_path / "test_dir"
+    (test_dir / "symlink_dir").symlink_to(tmp_path / "folder_to_symlink")
+    (test_dir / "symlink_file.txt").symlink_to(tmp_path / "file_to_symlink.txt")
+
+    def get_names(files: list[Path]) -> set[str]:
+        return {f.name for f in files}
+
+    # Collect excluding hidden and symlinks
+    files = collect_files(test_dir)
+    assert get_names(files) == {"file1.txt", "file2.txt", "nested_file.txt"}
+
+    # With hidden
+    files = collect_files(test_dir, include_hidden=True)
+    assert get_names(files) == {
+        "file1.txt",
+        "file2.txt",
+        "nested_file.txt",
+        ".hidden_file",
+        "file_in_hidden.txt",
+    }
+
+    # With symlinks
+    files = collect_files(test_dir, follow_symlinks=True)
+    assert get_names(files) == {
+        "file1.txt",
+        "file2.txt",
+        "nested_file.txt",
+        "file_in_symlink.txt",
+        "symlink_file.txt",
+    }
+
+    # With both
+    files = collect_files(test_dir, include_hidden=True, follow_symlinks=True)
+    assert get_names(files) == {
+        "file1.txt",
+        "file2.txt",
+        "nested_file.txt",
+        ".hidden_file",
+        "file_in_hidden.txt",
+        "file_in_symlink.txt",
+        "symlink_file.txt",
+    }
+
+    # Edge cases
+    assert collect_files(test_dir / "nonexistent") == []
+    regular_file = test_dir / "just_a_file"
+    regular_file.touch()
+    assert collect_files(regular_file) == []


### PR DESCRIPTION
## Description
- Instead of filtering symlinks after gathering all files, also add a follow_symlinks + include_hidden on collect_files. This avoids race conditions when files are created/deleted during collection

fixes https://github.com/OpenMined/syft-internal-issues/issues/226


## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
