### PR TITLE
Fix e2e - Federated Learning

### DIFF
--- a/tests/e2e/test_fl_model_training.py
+++ b/tests/e2e/test_fl_model_training.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from tests.e2e.conftest import Client, E2EContext, Server
 
-PROJECT_NAME = "my_cool_fl_project"
+PROJECT_NAME = "FedMNIST"
 
 AGGREGATOR_CONFIG = {
     "project_name": PROJECT_NAME,
@@ -106,12 +106,17 @@ async def approve_data_request(e2e_client: E2EContext, client: Client):
 
     # Approve request
     # Approve action is moving project dir to running dir
-    shutil.copytree(project_dir, running_dir / PROJECT_NAME, dirs_exist_ok=True)
-    shutil.rmtree(project_dir)
+    shutil.move(project_dir, running_dir)
 
-    # Wait for fl_config.json to be copied
+    # Ensure fl_config.json is present in running dir
     await e2e_client.wait_for_path(
         running_dir / PROJECT_NAME / "fl_config.json",
+        timeout=90,
+    )
+    
+    # Ensure model_arch is present in running dir
+    await e2e_client.wait_for_path(
+        running_dir / PROJECT_NAME / AGGREGATOR_CONFIG["model_arch"],
         timeout=90,
     )
 


### PR DESCRIPTION


## Description
The PR shifts to shutil.move when  approving a request as the move operation is atomic and does  os.rename if the filesystems being copied to is the same, which makes it very fast.

Also added a check to ensure all the files for training are present.
 
## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
