### PR TITLE
Remove source location in `server.log`

### DIFF
--- a/syftbox/server/logger.py
+++ b/syftbox/server/logger.py
@@ -49,6 +49,7 @@ def setup_logger(logs_folder: Path, level: Union[str, int] = "DEBUG") -> None:
         retention=2,  # Keep only the last 1 log files
         compression="zip",  # Usually, 10x reduction in file size
         filter=_default_logger_filter,
+        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {message}",  # matches the log format printed in the console
     )
 
     # Dedicated logger for analytics events


### PR DESCRIPTION
Currently we save the log in `server.log` with redundant source location, e.g. just repeated `syftbox.server.middleware:dispatch:14` like in the picture below
![image](https://github.com/user-attachments/assets/ba20beed-cc35-4651-aa54-f67cc39e39e7)

This is not useful since we print out logs from `middleware.py` and this line `syftbox.server.middleware:dispatch:14` is almost always repeated, which pollute the log info 

This PR removes that information and makes the logs in `server.log` same with the ones printed out on the console, which is ![image](https://github.com/user-attachments/assets/bf4e49c6-d16b-45f7-84df-5cd86c2fc70f)

This is good for our telemetry logs: This
![image](https://github.com/user-attachments/assets/ce133d97-3e63-4766-8690-706d6585cfd2)

instead of this:
![image](https://github.com/user-attachments/assets/c8ac7a63-1f2b-4cd0-b2f8-d6a3f47bc6f9)

