### PR TITLE
String custom headers

### DIFF
--- a/syftbox/lib/http.py
+++ b/syftbox/lib/http.py
@@ -2,13 +2,13 @@ from syftbox import __version__
 from syftbox.lib.platform import OS_ARCH, OS_NAME, OS_VERSION, PYTHON_VERSION
 
 # keep these as bytes as otel hooks return headers as bytes
-HEADER_SYFTBOX_VERSION = b"x-syftbox-version"
-HEADER_SYFTBOX_PYTHON = b"x-syftbox-python"
-HEADER_SYFTBOX_USER = b"x-syftbox-user"
-HEADER_OS_NAME = b"x-os-name"
-HEADER_OS_VERSION = b"x-os-ver"
-HEADER_OS_ARCH = b"x-os-arch"
-HEADER_GEO_COUNTRY = b"x-geo-country"  # Country of the user, added by Azure Front Door
+HEADER_SYFTBOX_VERSION = "x-syftbox-version"
+HEADER_SYFTBOX_USER = "x-syftbox-user"
+HEADER_SYFTBOX_PYTHON = "x-syftbox-python"
+HEADER_OS_NAME = "x-os-name"
+HEADER_OS_VERSION = "x-os-ver"
+HEADER_OS_ARCH = "x-os-arch"
+HEADER_GEO_COUNTRY = "x-geo-country"  # Country of the user, added by Azure Front Door
 
 SYFTBOX_HEADERS = {
     "User-Agent": f"SyftBox/{__version__} (Python {PYTHON_VERSION}; {OS_NAME} {OS_VERSION}; {OS_ARCH})",

--- a/syftbox/server/server.py
+++ b/syftbox/server/server.py
@@ -65,16 +65,15 @@ def create_folders(folders: list[Path]) -> None:
 def server_request_hook(span: Span, scope: dict[str, Any]) -> None:
     if not span.is_recording():
         return
-
     # headers k/v pairs are bytes
     headers: dict[bytes, bytes] = dict(scope.get("headers", {}))
-    span.set_attribute(OTEL_ATTR_CLIENT_VERSION, headers.get(HEADER_SYFTBOX_VERSION, ""))
-    span.set_attribute(OTEL_ATTR_CLIENT_PYTHON, headers.get(HEADER_SYFTBOX_PYTHON, ""))
-    span.set_attribute(OTEL_ATTR_CLIENT_USER, headers.get(HEADER_SYFTBOX_USER, ""))
-    span.set_attribute(OTEL_ATTR_CLIENT_OS_NAME, headers.get(HEADER_OS_NAME, ""))
-    span.set_attribute(OTEL_ATTR_CLIENT_OS_VER, headers.get(HEADER_OS_VERSION, ""))
-    span.set_attribute(OTEL_ATTR_CLIENT_OS_ARCH, headers.get(HEADER_OS_ARCH, ""))
-    span.set_attribute(OTEL_ATTR_CLIENT_USER_LOC, headers.get(HEADER_GEO_COUNTRY, ""))
+    span.set_attribute(OTEL_ATTR_CLIENT_VERSION, headers.get(HEADER_SYFTBOX_VERSION.encode(), ""))
+    span.set_attribute(OTEL_ATTR_CLIENT_PYTHON, headers.get(HEADER_SYFTBOX_PYTHON.encode(), ""))
+    span.set_attribute(OTEL_ATTR_CLIENT_USER, headers.get(HEADER_SYFTBOX_USER.encode(), ""))
+    span.set_attribute(OTEL_ATTR_CLIENT_OS_NAME, headers.get(HEADER_OS_NAME.encode(), ""))
+    span.set_attribute(OTEL_ATTR_CLIENT_OS_VER, headers.get(HEADER_OS_VERSION.encode(), ""))
+    span.set_attribute(OTEL_ATTR_CLIENT_OS_ARCH, headers.get(HEADER_OS_ARCH.encode(), ""))
+    span.set_attribute(OTEL_ATTR_CLIENT_USER_LOC, headers.get(HEADER_GEO_COUNTRY.encode(), ""))
 
 
 @contextlib.asynccontextmanager


### PR DESCRIPTION
Change custom headers to strings for `starlette` compatible and encode these strings to bytes for FastAPI OTel Collector request hooks